### PR TITLE
Make bimap diagram show correct output

### DIFF
--- a/lib/witchcraft/bifunctor.ex
+++ b/lib/witchcraft/bifunctor.ex
@@ -44,7 +44,7 @@ defclass Witchcraft.Bifunctor do
 
                    ┌------------------------------------┐
                    ↓                                    |
-        %Combo{a: 50, b: :ok, c: "hello"} |> bimap(&(&1 * 100), &String.upcase/1)
+        %Combo{a: 5, b: :ok, c: "hello"} |> bimap(&(&1 * 100), &String.upcase/1)
                                      ↑                                 |
                                      └---------------------------------┘
         #=> %Combo{a: 500, b: :ok, c: "HELLO"}


### PR DESCRIPTION
Reading the docs for `bimap`, I noticed the diagram has `50 * 100` equaling `500`. Changed `50` to `5` so the arithmetic lines up. :-)