### PR TITLE
Fix `__using__` for `override_kernel` and `except`

### DIFF
--- a/lib/witchcraft/applicative.ex
+++ b/lib/witchcraft/applicative.ex
@@ -31,9 +31,11 @@ defclass Witchcraft.Applicative do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Apply, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/apply.ex
+++ b/lib/witchcraft/apply.ex
@@ -128,9 +128,11 @@ defclass Witchcraft.Apply do
   @type fun :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Functor, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/arrow.ex
+++ b/lib/witchcraft/arrow.ex
@@ -44,9 +44,11 @@ defclass Witchcraft.Arrow do
   @type t :: fun()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Category, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/bifunctor.ex
+++ b/lib/witchcraft/bifunctor.ex
@@ -26,9 +26,11 @@ defclass Witchcraft.Bifunctor do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Functor, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/category.ex
+++ b/lib/witchcraft/category.ex
@@ -27,9 +27,11 @@ defclass Witchcraft.Category do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Semigroupoid, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -43,9 +43,11 @@ defclass Witchcraft.Chain do
   @type link :: (any() -> Chain.t())
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Apply, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/comonad.ex
+++ b/lib/witchcraft/comonad.ex
@@ -28,9 +28,11 @@ defclass Witchcraft.Comonad do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Extend, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/extend.ex
+++ b/lib/witchcraft/extend.ex
@@ -33,9 +33,11 @@ defclass Witchcraft.Extend do
   @type colink :: (Extend.t() -> any())
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Functor, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/foldable.ex
+++ b/lib/witchcraft/foldable.ex
@@ -41,25 +41,28 @@ defclass Witchcraft.Foldable do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
-    {:ok, new_opts} =
-      Keyword.get_and_update(opts, :except, fn except ->
-        {:ok, [length: 1, max: 2, min: 2] ++ (except || [])}
-      end)
+    overrides = [length: 1, max: 2, min: 2]
+    excepts = Keyword.get(opts, :except, [])
 
     if Access.get(opts, :override_kernel, true) do
+      kernel_imports = Macro.escape(except: overrides -- excepts)
+      module_imports = Macro.escape(except: excepts)
+
       quote do
         use Witchcraft.Semigroup, unquote(opts)
         use Witchcraft.Ord, unquote(opts)
 
-        import Kernel, unquote(new_opts)
-        import unquote(__MODULE__), unquote(opts)
+        import Kernel, unquote(kernel_imports)
+        import unquote(__MODULE__), unquote(module_imports)
       end
     else
+      module_imports = Macro.escape(except: Enum.uniq(overrides ++ excepts))
+
       quote do
         use Witchcraft.Semigroup, unquote(opts)
         use Witchcraft.Ord, unquote(opts)
 
-        import unquote(__MODULE__), unquote(new_opts)
+        import unquote(__MODULE__), unquote(module_imports)
       end
     end
   end

--- a/lib/witchcraft/functor.ex
+++ b/lib/witchcraft/functor.ex
@@ -23,8 +23,10 @@ defclass Witchcraft.Functor do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/monad.ex
+++ b/lib/witchcraft/monad.ex
@@ -43,10 +43,12 @@ defclass Witchcraft.Monad do
   use Witchcraft.Chain
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Applicative, unquote(opts)
       use Witchcraft.Chain, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/monoid.ex
+++ b/lib/witchcraft/monoid.ex
@@ -20,9 +20,11 @@ defclass Witchcraft.Monoid do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Semigroup, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 

--- a/lib/witchcraft/ord.ex
+++ b/lib/witchcraft/ord.ex
@@ -26,21 +26,24 @@ defclass Witchcraft.Ord do
   import Kernel, except: [<: 2, >: 2, <=: 2, >=: 2]
 
   defmacro __using__(opts \\ []) do
-    {:ok, new_opts} =
-      Keyword.get_and_update(opts, :except, fn except ->
-        {:ok, [<: 2, >: 2, <=: 2, >=: 2] ++ (except || [])}
-      end)
+    overrides = [<: 2, >: 2, <=: 2, >=: 2]
+    excepts = Keyword.get(opts, :except, [])
 
     if Access.get(opts, :override_kernel, true) do
+      kernel_imports = Macro.escape(except: overrides -- excepts)
+      module_imports = Macro.escape(except: excepts)
+
       quote do
-        import Kernel, unquote(new_opts)
+        import Kernel, unquote(kernel_imports)
         use Witchcraft.Semigroupoid, unquote(opts)
-        import unquote(__MODULE__), unquote(opts)
+        import unquote(__MODULE__), unquote(module_imports)
       end
     else
+      module_imports = Macro.escape(except: Enum.uniq(overrides ++ excepts))
+
       quote do
         use Witchcraft.Semigroupoid, unquote(opts)
-        import unquote(__MODULE__), unquote(new_opts)
+        import unquote(__MODULE__), unquote(module_imports)
       end
     end
   end

--- a/lib/witchcraft/semigroup.ex
+++ b/lib/witchcraft/semigroup.ex
@@ -27,18 +27,23 @@ defclass Witchcraft.Semigroup do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
-    {:ok, new_opts} =
-      Keyword.get_and_update(opts, :except, fn except ->
-        {:ok, [<>: 2] ++ (except || [])}
-      end)
+    overrides = [<>: 2]
+    excepts = Keyword.get(opts, :except, [])
 
     if Access.get(opts, :override_kernel, true) do
+      kernel_imports = Macro.escape(except: overrides -- excepts)
+      module_imports = Macro.escape(except: excepts)
+
       quote do
-        import Kernel, unquote(new_opts)
-        import unquote(__MODULE__), unquote(opts)
+        import Kernel, unquote(kernel_imports)
+        import unquote(__MODULE__), unquote(module_imports)
       end
     else
-      quote do: import(unquote(__MODULE__), unquote(new_opts))
+      module_imports = Macro.escape(except: Enum.uniq(overrides ++ excepts))
+
+      quote do
+        import unquote(__MODULE__), unquote(module_imports)
+      end
     end
   end
 

--- a/lib/witchcraft/semigroupoid.ex
+++ b/lib/witchcraft/semigroupoid.ex
@@ -18,18 +18,23 @@ defclass Witchcraft.Semigroupoid do
   @type t :: any()
 
   defmacro __using__(opts \\ []) do
-    {:ok, new_opts} =
-      Keyword.get_and_update(opts, :except, fn except ->
-        {:ok, [apply: 2] ++ (except || [])}
-      end)
+    overrides = [apply: 2]
+    excepts = Keyword.get(opts, :except, [])
 
     if Access.get(opts, :override_kernel, true) do
+      kernel_imports = Macro.escape(except: overrides -- excepts)
+      module_imports = Macro.escape(except: excepts)
+
       quote do
-        import Kernel, unquote(new_opts)
-        import unquote(__MODULE__), unquote(opts)
+        import Kernel, unquote(kernel_imports)
+        import unquote(__MODULE__), unquote(module_imports)
       end
     else
-      quote do: import(unquote(__MODULE__), unquote(new_opts))
+      module_imports = Macro.escape(except: Enum.uniq(overrides ++ excepts))
+
+      quote do
+        import unquote(__MODULE__), unquote(module_imports)
+      end
     end
   end
 

--- a/lib/witchcraft/traversable.ex
+++ b/lib/witchcraft/traversable.ex
@@ -34,10 +34,12 @@ defclass Witchcraft.Traversable do
   @type link :: (any() -> Traversable.t())
 
   defmacro __using__(opts \\ []) do
+    module_imports = [except: Keyword.get(opts, :except, [])]
+
     quote do
       use Witchcraft.Foldable, unquote(opts)
       use Witchcraft.Functor, unquote(opts)
-      import unquote(__MODULE__), unquote(opts)
+      import unquote(__MODULE__), unquote(module_imports)
     end
   end
 


### PR DESCRIPTION
For example,
```
use Witchcraft, override_kernel: false, except: [>=: 2]
```
would fail to compile because

1. `override_kernel` is passed into opts in `import unquote(__MODULE__), unquote(opts)` that renders wrong argument.

2. `except: [>=2]`is passed to `Ord.__using__` and its `[>=:2, ...] ++ except` makes duplicated entry in `new_opts` in `import unquote(__MODULE__), except: unquote(new_opts)` which causes compile error.


This PR fixes above bugs.