### PR TITLE
Allow nested monad return

### DIFF
--- a/lib/witchcraft/monad.ex
+++ b/lib/witchcraft/monad.ex
@@ -201,6 +201,13 @@ defclass Witchcraft.Monad do
       [1]
 
       iex> monad [] do
+      ...>   monad {999} do
+      ...>     return 1
+      ...>   end
+      ...> end
+      {1}
+
+      iex> monad [] do
       ...>  a <- [1,2,3]
       ...>  b <- [4,5,6]
       ...>  return(a * b)
@@ -286,6 +293,12 @@ defclass Witchcraft.Monad do
   def desugar_return(ast, sample) do
     ast
     |> Macro.prewalk(fn
+      {:monad = f, ctx, [inner_sample, inner_ast]} ->
+        {f, ctx, [inner_sample, desugar_return(inner_ast, inner_sample)]}
+
+      {{:., _, [_aliases, :monad]} = f, ctx, [inner_sample, inner_ast]} ->
+        {f, ctx, [inner_sample, desugar_return(inner_ast, inner_sample)]}
+
       {:return, _ctx, [inner]} ->
         quote do: Witchcraft.Applicative.of(unquote(sample), unquote(inner))
 


### PR DESCRIPTION
Make `return` in monad to be desugarized according to sample of inner-most monad.