### PR TITLE
fully qualify Witchcraft.Apply.then/2 to avoid name conflict in Elixir 1.12+

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.0.5
-elixir 1.9.1
+erlang 24.0.5
+elixir 1.12.2

--- a/lib/witchcraft/apply.ex
+++ b/lib/witchcraft/apply.ex
@@ -378,8 +378,8 @@ defclass Witchcraft.Apply do
   ## Examples
 
       iex> [1, 2, 3]
-      ...> |> then([4, 5, 6])
-      ...> |> then([7, 8, 9])
+      ...> |> Witchcraft.Apply.then([4, 5, 6])
+      ...> |> Witchcraft.Apply.then([7, 8, 9])
       [
         7, 8, 9,
         7, 8, 9,
@@ -392,7 +392,7 @@ defclass Witchcraft.Apply do
         7, 8, 9
       ]
 
-      iex> {1, 2, 3} |> then({4, 5, 6}) |> then({7, 8, 9})
+      iex> {1, 2, 3} |> Witchcraft.Apply.then({4, 5, 6}) |> Witchcraft.Apply.then({7, 8, 9})
       {12, 15, 9}
 
   """

--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -410,7 +410,7 @@ defclass Witchcraft.Chain do
 
   @doc false
   # credo:disable-for-lines:31 Credo.Check.Refactor.Nesting
-  def do_notation(input, chainer) do
+  def do_notation(input, _chainer) do
     input
     |> normalize()
     |> Enum.reverse()

--- a/lib/witchcraft/foldable.ex
+++ b/lib/witchcraft/foldable.ex
@@ -748,7 +748,7 @@ defclass Witchcraft.Foldable do
       |> hd()
       |> of(%Unit{})
 
-    right_fold(foldable_monad, seed, &then/2)
+    right_fold(foldable_monad, seed, &Witchcraft.Apply.then/2)
   end
 
   @doc """
@@ -782,7 +782,7 @@ defclass Witchcraft.Foldable do
     right_fold(foldable, of(foldable, %Unit{}), fn step, acc ->
       step
       |> fun.()
-      |> then(acc)
+      |> Witchcraft.Apply.then(acc)
     end)
   end
 


### PR DESCRIPTION
## Summary
Elixir 1.12 introduces a new kernel method: `Kernel.then/2`, this causes witchcraft to not compile on Elixir 1.12+ with 
```== Compilation error in file lib/witchcraft/foldable.ex ==
** (CompileError) lib/witchcraft/foldable.ex:751: function then/2 imported from both Witchcraft.Apply and Kernel, call is ambiguous
    (elixir 1.12.0-rc.1) src/elixir_dispatch.erl:42: :elixir_dispatch.import_function/4
    (elixir 1.12.0-rc.1) src/elixir_fn.erl:76: :elixir_fn.capture_import/4
    (stdlib 3.14.2) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.14.2) lists.erl:1359: :lists.mapfoldl/3
```
This PR fully qualifies `Witchcraft.Apply.then/2` so that `then/2` is no longer ambiguous. 

This PR fixes/implements the following **bugs/features**

* [ ] Support Elixir 1.12+

Explain the **motivation** for making this change. What existing problem does the pull request solve?
You can't use witchcraft on Elixir 1.12+.

## Test plan (required)

Run the tests with Elixir 1.12.2

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [ ] Does this change require a release to be made? Is so please create and deploy the release
